### PR TITLE
Updated to use new Formular API

### DIFF
--- a/Config/CustomConfiguration.xcconfig
+++ b/Config/CustomConfiguration.xcconfig
@@ -12,5 +12,8 @@
 PRODUCT_BUNDLE_IDENTIFIER = com.mycompany.MyOtherAppName
 DEVELOPMENT_TEAM = ""
 CODE_SIGN_STYLE = Manual
+API_URL = https:/$()/mv-mobile-prod.azurewebsites.net/api/v1 // production
+
+//API_URL = https:/$()/mv-mobile-dev.azurewebsites.net/api/v1 // dev - use this in your LocalConfiguration.xcconfig
 
 #include? "LocalConfiguration.xcconfig"

--- a/Config/README.md
+++ b/Config/README.md
@@ -6,6 +6,10 @@ In order to run the app on your device, make sure you create a `LocalConfigurati
 
 This file will not be committed to the repository (it's in the `.gitignore`), but will be included by XCode and it will update the information automatically. Also, because we're using this local config structure, don't make changes to the build settings regarding the bundle id, team id or signing preference. If you did so, just delete the custom values and let the build settings be updated from the xcconfig files.
 
+If you want to use the `dev` API, copy the Development link that's commented in the `CustomConfiguration.xcconfig` and use it in your own `LocalConfiguration.xcconfig`. If you want to test production, don't add an `API_URL` variable at all.
+
+This might seem obvious, but don't make any changes directly into `CustomConfiguration.xcconfig`, because they'll be committed with the rest of the changes. Use `LocalConfiguration.xcconfig` for your own configs.
+
 If you're interested in how this works, check out [this tutorial](https://www.matrixprojects.net/p/xcconfig-for-shared-projects/)
 
 ## Firebase

--- a/MonitorizareVot.xcodeproj/project.pbxproj
+++ b/MonitorizareVot.xcodeproj/project.pbxproj
@@ -1164,7 +1164,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = code4ro.MonitorizareVotTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MonitorizareVot.app/MonitorizareVot";
 			};
 			name = Debug;
@@ -1179,7 +1179,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = code4ro.MonitorizareVotTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MonitorizareVot.app/MonitorizareVot";
 			};
 			name = Release;
@@ -1194,7 +1194,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = code4ro.MonitorizareVotUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5;
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = MonitorizareVot;
 			};
 			name = Debug;
@@ -1209,7 +1209,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = code4ro.MonitorizareVotUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5;
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = MonitorizareVot;
 			};
 			name = Release;

--- a/MonitorizareVot/APIURLs.swift
+++ b/MonitorizareVot/APIURLs.swift
@@ -2,11 +2,11 @@
 
 import Foundation
 
-let baseUrlQA = "https://mv-mobile-prod.azurewebsites.net/api/v1"
-
 enum APIURLs {
     case login
-    case formsVersions
+    @available(*, deprecated, message: "use `forms` instead")
+    case formsVersions // deprecated
+    case forms
     case form
     case note
     case answeredQuestion
@@ -19,6 +19,8 @@ enum APIURLs {
                 return baseUrlQA + "/access/token"
             case .formsVersions:
                 return baseUrlQA + "/formular/versiune"
+            case .forms:
+                return baseUrlQA + "/formular"
             case .form:
                 return baseUrlQA + "/formular"
             case .note:
@@ -30,4 +32,14 @@ enum APIURLs {
             }
         }
     }
+    
+    var baseUrlQA: String {
+        if let info = Bundle.main.infoDictionary,
+            let urlString = info["API_URL"] as? String {
+            return urlString
+        }
+        return ""
+    }
+    
+
 }

--- a/MonitorizareVot/AddNoteViewController.swift
+++ b/MonitorizareVot/AddNoteViewController.swift
@@ -158,7 +158,7 @@ class AddNoteViewController: RootViewController, UITextViewDelegate, MVUITextVie
                 alertController.addAction(cancel)
                 self.present(alertController, animated: true, completion: nil)
             @unknown default:
-                let alertController = UIAlertController(title: "AlertTitle_UnknownError".localized, preferredStyle: .alert)
+                let alertController = UIAlertController(title: "AlertTitle_UnknownError".localized, message: "", preferredStyle: .alert)
                 let cancel = UIAlertAction(title: "Button_Close".localized, style: .cancel, handler: nil)
                 alertController.addAction(cancel)
                 self.present(alertController, animated: true, completion: nil)

--- a/MonitorizareVot/Base.lproj/Localizable.strings
+++ b/MonitorizareVot/Base.lproj/Localizable.strings
@@ -57,7 +57,7 @@
 "AlertTitle_CountyNumberInvalid" = "Department number is invalid";
 "AlertMessage_CountyNumberInvalid" = "We didn't find any department for given number.";
 "AlertTitle_AccessRestricted" = "Access restricted";
-"AlertTitle_UnknownError" = "Unknown Error"
+"AlertTitle_UnknownError" = "Unknown Error";
 "AlertMessage_EnableCameraAccess" = "Please access the settings and give us permissions to access the picture library.";
 
 "AlertButton_Understood" = "I understood";

--- a/MonitorizareVot/FormFetcher.swift
+++ b/MonitorizareVot/FormFetcher.swift
@@ -15,19 +15,21 @@ class FormFetcher {
     weak var delegate: FormFetcherDelegate?
     var formName: String
     var version: Int
+    var description: String
     var informations: [[String :AnyObject]]?
     
-    init(form: String, newVersion: Int) {
+    init(form: String, newVersion: Int, newDescription: String) {
         formName = form
         version = newVersion
+        description = newDescription
     }
     
     func fetch(completion: FormFetcherCompletion) {
-        let url = APIURLs.form.url
+        let url = APIURLs.form.url + "/" + formName
         if let token = KeychainWrapper.standard.string(forKey: "token") {
             let headers = ["Content-Type": "application/x-www-form-urlencoded",
                            "Authorization" :"Bearer " + token]
-            Alamofire.request(url, method: .get, parameters: ["idformular": formName], headers: headers).responseJSON { (response:DataResponse<Any>) in
+            Alamofire.request(url, method: .get, parameters: nil, headers: headers).responseJSON { (response:DataResponse<Any>) in
                 switch response.result {
                 case .success(_):
                     if let data = response.result.value as? [[String :AnyObject]] {

--- a/MonitorizareVot/FormPickerCollectionViewCell.swift
+++ b/MonitorizareVot/FormPickerCollectionViewCell.swift
@@ -25,6 +25,8 @@ class FormPickerCollectionViewCell: UICollectionViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         
+        self.clipsToBounds = false
+        contentView.clipsToBounds = false
         contentView.layer.dropDefaultShadow()
         contentView.layer.defaultCornerRadius(borderColor: MVColors.gray.cgColor)
 

--- a/MonitorizareVot/FormsFetcher.swift
+++ b/MonitorizareVot/FormsFetcher.swift
@@ -18,20 +18,22 @@ class FormsFetcher: FormFetcherDelegate {
     
     func fetch(completion: @escaping FormsFetcherCompletion) {
         self.completion = completion
-        let url = APIURLs.formsVersions.url
+        let url = APIURLs.forms.url
         if let token = KeychainWrapper.standard.string(forKey: "token") {
             let headers = ["Content-Type": "application/x-www-form-urlencoded",
                            "Authorization" :"Bearer " + token]
             Alamofire.request(url, method: .get, parameters: nil, encoding: JSONEncoding.default, headers: headers).responseJSON { (response:DataResponse<Any>) in
                 switch response.result {
                 case .success(_):
-                    if let data = response.result.value as? [String: AnyObject], let versionsInformations = data["versiune"] as? [String: AnyObject] {
-                        for (aVersionKey, aVersionNumber) in versionsInformations {
-                            if let aVersionNumber = aVersionNumber as? Int {
-                                let version = self.formsPersistor.getVersion(forForm: aVersionKey)
-                                if version < aVersionNumber {
-                                    self.performFetchForForm(formName: aVersionKey, newVersion: aVersionNumber)
-                                }
+                    if let data = response.result.value as? [String: AnyObject], let versionsInformations = data["formulare"] as? [[String: AnyObject]] {
+                        for form in versionsInformations {
+                            let ver = form["ver"] as? Int ?? 1
+                            let code = form["code"] as? String ?? ""
+                            let description = form["description"] as? String ?? ""
+                            
+                            let version = self.formsPersistor.getVersion(forForm: code)
+                            if version < ver {
+                                self.performFetchForForm(formName: code, newVersion: ver, newDescription: description)
                             }
                         }
                     }
@@ -45,8 +47,8 @@ class FormsFetcher: FormFetcherDelegate {
         }
     }
     
-    private func performFetchForForm(formName: String, newVersion: Int) {
-        let formFetcher = FormFetcher(form: formName, newVersion: newVersion)
+    private func performFetchForForm(formName: String, newVersion: Int, newDescription: String) {
+        let formFetcher = FormFetcher(form: formName, newVersion: newVersion, newDescription: newDescription)
         formFetcher.delegate = self
         formsInformationsFetchers.append(formFetcher)
         formFetcher.fetch {[weak self] (tokenExpired) in
@@ -60,7 +62,7 @@ class FormsFetcher: FormFetcherDelegate {
     func didFinishRequest(fetcher: FormFetcher) {
         if let index = formsInformationsFetchers.firstIndex(where : { $0 == fetcher}) {
             if let informations = fetcher.informations {
-                formsPersistor.save(version: fetcher.version, name: fetcher.formName, informations: informations)
+                formsPersistor.save(version: fetcher.version, id: fetcher.formName, description: fetcher.description, informations: informations)
             }
             formsInformationsFetchers.remove(at: index)
         }

--- a/MonitorizareVot/FormsPersistor.swift
+++ b/MonitorizareVot/FormsPersistor.swift
@@ -3,8 +3,9 @@
 import Foundation
 
 protocol FormsPersistor {
-    func save(version: Int, name: String, informations: [[String :AnyObject]])
+    func save(version: Int, id: String, description: String, informations: [[String : AnyObject]])
     
+    func getForm(withId id: String) -> [String: Any]?
     func getVersion(forForm: String) -> Int
-    func getInformations(forForm: String) -> [[String :AnyObject]]?
+    func getInformations(forForm: String) -> [[String: AnyObject]]?
 }

--- a/MonitorizareVot/Info.plist
+++ b/MonitorizareVot/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>API_URL</key>
+	<string>$(API_URL)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>ro</string>
 	<key>CFBundleDisplayName</key>

--- a/MonitorizareVot/LocalFormProvider.swift
+++ b/MonitorizareVot/LocalFormProvider.swift
@@ -8,15 +8,18 @@ class LocalFormProvider: FormProvider {
     private var formsPersistor = LocalFormsPersistor()
     
     func getForm(named: String) -> Form? {
-        if let formSections = formsPersistor.getInformations(forForm: named) {
-            return createForm(informations: formSections, named: named)
+        
+        if let summary = formsPersistor.getForm(withId: named),
+            let formSections = formsPersistor.getInformations(forForm: named) {
+            let description = summary[LocalFormsPersistor.FormSummaryKeys.description] as? String ?? named // default to the name
+            return createForm(informations: formSections, named: named, description: description)
         }
         return nil
     }
     
     
-    private func createForm(informations: [[String: AnyObject]], named: String) -> Form {
-        return Form(id: named, title: "Procedurile ...", sections: createSection(informations: informations, named: named))
+    private func createForm(informations: [[String: AnyObject]], named: String, description: String) -> Form {
+        return Form(id: named, title: description, sections: createSection(informations: informations, named: named))
     }
     
     private func createSection(informations: [[String: AnyObject]], named: String) -> [MVSection] {

--- a/MonitorizareVot/LocalFormsPersistor.swift
+++ b/MonitorizareVot/LocalFormsPersistor.swift
@@ -6,28 +6,44 @@ import Foundation
 class LocalFormsPersistor: FormsPersistor {
 
     fileprivate enum UserDefaultsKeys: String {
+        @available(*, deprecated, message: "use `formList` instead")
         case forms = "forms"
+        case formList = "formList"
         case formPrefix = "form:"
+    }
+    
+    enum FormSummaryKeys {
+        static let id = "id"
+        static let version = "ver"
+        static let description = "description"
     }
     
     // MARK: - Public
     
     /// Saves the form summary (id and version), along with the form details
-    func save(version: Int, name: String, informations: [[String : AnyObject]]) {
-        saveFormSummary(withId: name, version: version)
-        saveFormSections(withId: name, sections: informations)
+    func save(version: Int, id: String, description: String, informations: [[String : AnyObject]]) {
+        saveFormSummary(withId: id, version: version, description: description)
+        saveFormSections(withId: id, sections: informations)
     }
     
-    /// Returns the list of all form ids
-    func getAllForms() -> [String] {
+    /// Returns the list of all forms
+    func getAllForms() -> [[String: Any]] {
         let forms = getAllFormSummaries()
-        return Array(forms.keys).sorted()
+        return forms.sorted { ($0[FormSummaryKeys.id] as! String) < ($1[FormSummaryKeys.id] as! String) }
     }
     
     /// Fetches the version of the specified form or 0 if not found
     func getVersion(forForm id: String) -> Int {
-        let forms = getAllFormSummaries()
-        return forms[id] ?? 0
+        if let form = getForm(withId: id) {
+            return form[FormSummaryKeys.version] as? Int ?? 0
+        }
+        return 0
+    }
+    
+    /// Gets the full form summary object
+    func getForm(withId id: String) -> [String : Any]? {
+        let form = (getAllFormSummaries().filter { $0["id"] as? String == id }).first
+        return form
     }
 
     /// Fetches the full form from storage
@@ -42,17 +58,25 @@ class LocalFormsPersistor: FormsPersistor {
     
     // MARK: - Internals
     
-    /// Saves the form summary as a hash ([id: version])
-    fileprivate func saveFormSummary(withId id: String, version: Int) {
-        let key = UserDefaultsKeys.forms.rawValue
-        var forms: [String: Int] = [:]
+    /// Saves the form summary as a hash
+    fileprivate func saveFormSummary(withId id: String, version: Int, description: String) {
+        guard id.count > 0 else { return } // make sure we have a valid id
+        
+        let key = UserDefaultsKeys.formList.rawValue
+        var forms: [[String: Any]] = []
         if let data = UserDefaults.standard.value(forKey: key) as? Data {
-            if let object = NSKeyedUnarchiver.unarchiveObject(with: data) as? [String: Int] {
+            if let object = NSKeyedUnarchiver.unarchiveObject(with: data) as? [[String: Any]] {
                 forms = object
             }
         }
         
-        forms[id] = version
+        var form: [String: Any] = [:]
+        form[FormSummaryKeys.id] = id
+        form[FormSummaryKeys.version] = version
+        form[FormSummaryKeys.description] = description
+        
+        forms.removeAll { $0[FormSummaryKeys.id] as? String == id }
+        forms.append(form)
         
         let data = NSKeyedArchiver.archivedData(withRootObject: forms)
         UserDefaults.standard.set(data, forKey: key)
@@ -67,10 +91,10 @@ class LocalFormsPersistor: FormsPersistor {
         UserDefaults.standard.synchronize()
     }
     
-    fileprivate func getAllFormSummaries() -> [String: Int] {
-        guard let data = UserDefaults.standard.value(forKey: UserDefaultsKeys.forms.rawValue) as? Data else { return [:] }
+    fileprivate func getAllFormSummaries() -> [[String: Any]] {
+        guard let data = UserDefaults.standard.value(forKey: UserDefaultsKeys.formList.rawValue) as? Data else { return [] }
         
-        guard let forms = NSKeyedUnarchiver.unarchiveObject(with: data) as? [String: Int] else { return [:] }
+        guard let forms = NSKeyedUnarchiver.unarchiveObject(with: data) as? [[String: Any]] else { return [] }
         
         return forms
     }

--- a/MonitorizareVot/PickFormViewController.swift
+++ b/MonitorizareVot/PickFormViewController.swift
@@ -21,8 +21,7 @@ class PickFormViewController: RootViewController {
     @IBOutlet private weak var topLabel: UILabel!
     private let dbSyncer = DBSyncer()
 
-    // TODO: move this into an object or hash when we have more data to show
-    var forms: [String] = []
+    var forms: [[String: Any]] = []
     
     fileprivate let FormCellPadding: CGFloat = 5
     
@@ -68,6 +67,7 @@ class PickFormViewController: RootViewController {
         syncButton?.setTitle("Button_SyncData".localized, for: .normal)
         
         formsCollectionView.register(UINib(nibName: "FormPickerCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: FormPickerCollectionViewCell.reuseIdentifier)
+        formsCollectionView.clipsToBounds = false
     }
     
     private func setupOutlets() {
@@ -107,6 +107,7 @@ class PickFormViewController: RootViewController {
             formViewController.form = type
             formViewController.sectionInfo = sectionInfo
             formViewController.persistedSectionInfo = persistedSectionInfo
+            formViewController.title = form.title
             self.navigationController?.pushViewController(formViewController, animated: true)
         }
     }
@@ -134,8 +135,8 @@ extension PickFormViewController: UICollectionViewDataSource, UICollectionViewDe
         } else {
             cell.isAddNote = false
             let form = forms[indexPath.row]
-            cell.idLabel.text = form.uppercased()
-            cell.descriptionLabel.text = "Label_Form".localized
+            cell.idLabel.text = (form[LocalFormsPersistor.FormSummaryKeys.id] as? String)?.uppercased()
+            cell.descriptionLabel.text = (form[LocalFormsPersistor.FormSummaryKeys.description] as? String)?.capitalized
         }
         
         return cell
@@ -145,7 +146,9 @@ extension PickFormViewController: UICollectionViewDataSource, UICollectionViewDe
         if indexPath.row == collectionView.numberOfItems(inSection: 0) - 1 {
             handleAddNoteAction()
         } else {
-            self.pushFormViewController(type: forms[indexPath.row])
+            let form = forms[indexPath.row]
+            let id = form[LocalFormsPersistor.FormSummaryKeys.id] as! String
+            self.pushFormViewController(type: id)
         }
     }
     

--- a/MonitorizareVot/ro.lproj/Localizable.strings
+++ b/MonitorizareVot/ro.lproj/Localizable.strings
@@ -56,7 +56,7 @@
 "AlertTitle_CountyNumberInvalid" = "Codul secției este invalid";
 "AlertMessage_CountyNumberInvalid" = "Nu a fost gasită nici o secție care sa aibă acest număr.";
 "AlertTitle_AccessRestricted" = "Accessul este restricționat";
-"AlertTitle_UnknownError" = "Eroare Necunoscută"
+"AlertTitle_UnknownError" = "Eroare Necunoscută";
 "AlertMessage_EnableCameraAccess" = "Te rugăm să accesezi setările și să ne oferi permisiuni de acces la librăria de poze.";
 
 "AlertButton_Understood" = "Am înțeles";


### PR DESCRIPTION
Added API_URL to custom config and updated docs;
Fixed some bugs that seem to got there via a previous merge;
Updated API to use the `/formular` and `/formular/:id` endpoints instead of the old ones;
Updated UI and local persistor to make use of the above change;
Fixed some issues with Cocoapods and Swift 5 inconsistency.