### PR TITLE
Camera/Gallery chooser for note attachments

### DIFF
--- a/MonitorizareVot/Base.lproj/Localizable.strings
+++ b/MonitorizareVot/Base.lproj/Localizable.strings
@@ -35,6 +35,10 @@
 "Label_AddNote" = "Add a note";
 "Label_TypeNote" = "Type your note here";
 
+"Option.Gallery" = "Load from gallery";
+"Option.TakePhoto" = "Take a photo";
+"Option.RecordVideo" = "Record a video";
+
 "AlertMessage_EnableCameraAccess" = "Please access the settings and give us permissions to access the picture library.";
 
 "Error_Unknown" = "An unknown error occured";

--- a/MonitorizareVot/MVAnalytics.swift
+++ b/MonitorizareVot/MVAnalytics.swift
@@ -32,7 +32,7 @@ enum MVAnalyticsEvent {
 
     var name: String {
         switch self {
-        case .screen:               return "screen_view"
+        case .screen:               return "screen"
         case .onboardingPage:       return "onboarding_page"
         case .loginFailed:          return "login_failed"
         case .pushNotificationsAllowed: return "push_allowed"

--- a/MonitorizareVot/en.lproj/InfoPlist.strings
+++ b/MonitorizareVot/en.lproj/InfoPlist.strings
@@ -8,3 +8,4 @@
 
 NSPhotoLibraryUsageDescription = "We need access to your photo library to be able to attach a photo or video to the note";
 NSCameraUsageDescription = "We need access to your camera to be able to attach a photo or video to the note";
+NSMicrophoneUsageDescription = "We need access to your microphone when you record videos to attach to notes";

--- a/MonitorizareVot/ro.lproj/InfoPlist.strings
+++ b/MonitorizareVot/ro.lproj/InfoPlist.strings
@@ -6,5 +6,6 @@
   Copyright © 2019 Code4Ro. All rights reserved.
 */
 
-NSPhotoLibraryUsageDescription = "Avem nevoie de acces la librăria de poze pentru a putea atașa o poză notei.";
-NSCameraUsageDescription = "Avem nevoie de acces la camera foto pentru a putea atașa o poză sau un film notei.";
+NSPhotoLibraryUsageDescription = "Avem nevoie de acces la librăria de poze pentru a putea atașa o poză notelor.";
+NSCameraUsageDescription = "Avem nevoie de acces la camera foto pentru a putea atașa o poză sau un film notelor.";
+NSMicrophoneUsageDescription = "Avem nevoie de acces la microfon pentru a putea înregistra clipurile de atașat notelor.";

--- a/MonitorizareVot/ro.lproj/Localizable.strings
+++ b/MonitorizareVot/ro.lproj/Localizable.strings
@@ -35,6 +35,10 @@
 "Label_AddNote" = "Adaugă o notă";
 "Label_TypeNote" = "Scrie aici nota";
 
+"Option.Gallery" = "Încarcă din galerie";
+"Option.TakePhoto" = "Fă o fotografie";
+"Option.RecordVideo" = "Înregistrează un film";
+
 "AlertMessage_EnableCameraAccess" = "Te rugăm să accesezi setările și să ne oferi permisiuni de acces la librăria de poze.";
 
 "Error_Unknown" = "A apărut o eroare necunoscută";


### PR DESCRIPTION
Implemented menu to allow user to choose photo/video source when uploading a note;
Renamed screen view event to not conflict with the firebase one;
Added camera permission localized descriptions