### PR TITLE
Some fixes for the last app update

### DIFF
--- a/MonitorizareVot.xcodeproj/project.pbxproj
+++ b/MonitorizareVot.xcodeproj/project.pbxproj
@@ -1240,10 +1240,11 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = MonitorizareVot/MonitorizareVot.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 11;
 				INFOPLIST_FILE = MonitorizareVot/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 2.1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1259,10 +1260,11 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = MonitorizareVot/MonitorizareVot.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 11;
 				INFOPLIST_FILE = MonitorizareVot/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 2.1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 5.0;

--- a/MonitorizareVot/Form/AttachNoteViewController.swift
+++ b/MonitorizareVot/Form/AttachNoteViewController.swift
@@ -30,6 +30,9 @@ class AttachNoteViewController: UIViewController {
     
     var onAttachmentRequest: ((_ sourceView: UIView) -> Void)?
     
+    /// Called back when a note was successfully saved (so you can update the interface with the latest data)
+    var onNoteSaved: (() -> Void)?
+    
     // MARK: - Object
     
     init(withModel model: AttachNoteViewModel) {
@@ -89,12 +92,15 @@ class AttachNoteViewController: UIViewController {
     // MARK: - UI
     
     fileprivate func updateInterface() {
-        submitButton.isEnabled = model.canBeSaved
+        submitButton.isEnabled = model.canBeSaved && !model.isSaving
         statusIcon.isHidden = !model.isSaved
         statusIcon.image = model.isSynced ? #imageLiteral(resourceName: "icon-check") : #imageLiteral(resourceName: "icon-check-greyed")
         textViewPlaceHolder.isHidden = model.text.count > 0
         attachmentStackView.isHidden = model.attachment == nil
         filenameLabel.text = model.attachment?.filename
+        if !textView.isFirstResponder {
+            textView.text = model.text
+        }
     }
     
     // MARK: - Actions
@@ -110,15 +116,16 @@ class AttachNoteViewController: UIViewController {
     }
     
     @IBAction func handleSubmitAction(_ sender: Any) {
-        submitButton.isEnabled = false
+        textView.resignFirstResponder()
         model.saveAndUpload { [weak self] error in
             guard let self = self else { return }
             if let error = error,
                 case AttachNoteError.saveFailed = error {
                 let alert = UIAlertController.error(withMessage: error.localizedDescription)
                 self.present(alert, animated: true, completion: nil)
-                self.submitButton.isEnabled = true
             } else {
+                self.onNoteSaved?()
+                
                 // back out
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                     self.navigationController?.popViewController(animated: true)

--- a/MonitorizareVot/Form/NoteViewController.swift
+++ b/MonitorizareVot/Form/NoteViewController.swift
@@ -91,6 +91,10 @@ class NoteViewController: MVViewController {
         attachNoteController.onAttachmentRequest = { [weak self] sourceView in
             self?.showAttachmentOptions(from: sourceView)
         }
+        attachNoteController.onNoteSaved = { [weak self] in
+            self?.model.load()
+            self?.historyTableView.reloadData()
+        }
 
     }
     

--- a/MonitorizareVot/Form/NoteViewModel.swift
+++ b/MonitorizareVot/Form/NoteViewModel.swift
@@ -25,6 +25,10 @@ class NoteViewModel: NSObject {
     init(withQuestionId questionId: Int? = nil) {
         self.questionId = questionId
         super.init()
+        load()
+    }
+    
+    func load() {
         notes = DB.shared.getNotes(attachedToQuestion: questionId).map { model(fromDbObject: $0) }
     }
     

--- a/MonitorizareVot/Form/QuestionAnswerViewController.swift
+++ b/MonitorizareVot/Form/QuestionAnswerViewController.swift
@@ -12,6 +12,7 @@ class QuestionAnswerViewController: MVViewController {
     
     /// Will post this notification every time the user goes to the next/previous question. You can listen to this in your question list and update as necessary
     static let questionChangedNotification = Notification.Name("QuestionChangedNotification")
+    static let questionSavedNotification = Notification.Name("QuestionSavedNotification")
     static let questionUserInfoKey = "question"
     
     var model: QuestionAnswerViewModel
@@ -81,6 +82,7 @@ class QuestionAnswerViewController: MVViewController {
     
     fileprivate func bindToUpdateEvents() {
         model.onModelUpdate = { [weak self] in
+            NotificationCenter.default.post(name: QuestionAnswerViewController.questionSavedNotification, object: nil)
             self?.updateInterface()
         }
         NotificationCenter.default.addObserver(self, selector: #selector(handleOrientationChange), name: UIDevice.orientationDidChangeNotification, object: nil)
@@ -112,7 +114,6 @@ class QuestionAnswerViewController: MVViewController {
             lastViewedQuestionIndex = currentPage
 
             let question = model.questions[currentPage]
-            DebugLog("question changed to: \(question)")
             NotificationCenter.default.post(name: QuestionAnswerViewController.questionChangedNotification,
                                             object: self,
                                             userInfo: [QuestionAnswerViewController.questionUserInfoKey: question])
@@ -157,11 +158,13 @@ class QuestionAnswerViewController: MVViewController {
             askForText(ofQuestion: question, answerIndex: answerIndex) { text in
                 self.model.updateUserText(ofQuestion: question, answerIndex: answerIndex, userText: text)
                 self.updateInterface()
+                NotificationCenter.default.post(name: QuestionAnswerViewController.questionSavedNotification, object: nil)
             }
         } else {
             // first update the answer selection
             model.updateSelection(ofQuestion: question, answerIndex: answerIndex)
             updateInterface()
+            NotificationCenter.default.post(name: QuestionAnswerViewController.questionSavedNotification, object: nil)
         }
         
     }

--- a/MonitorizareVot/Form/QuestionListViewController.swift
+++ b/MonitorizareVot/Form/QuestionListViewController.swift
@@ -61,6 +61,8 @@ class QuestionListViewController: MVViewController {
     fileprivate func bindToNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(handleQuestionChanged(_:)),
                                                name: QuestionAnswerViewController.questionChangedNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleQuestionSaved(_:)),
+                                               name: QuestionAnswerViewController.questionSavedNotification, object: nil)
     }
 
     // MARK: - UI
@@ -84,6 +86,10 @@ class QuestionListViewController: MVViewController {
             tableView.reloadData()
             tableView.selectRow(at: indexPath, animated: true, scrollPosition: .middle)
         }
+    }
+
+    @objc func handleQuestionSaved(_ notification: Notification) {
+        tableView.reloadData()
     }
 }
 

--- a/MonitorizareVot/Info.plist
+++ b/MonitorizareVot/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.3</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>GUIDE_URL</key>

--- a/MonitorizareVot/Utility/TimePickerViewController.xib
+++ b/MonitorizareVot/Utility/TimePickerViewController.xib
@@ -88,7 +88,7 @@
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="WeD-so-1q4" firstAttribute="trailing" secondItem="YP7-6a-xZ6" secondAttribute="trailing" priority="999" id="6fW-4z-bvF"/>
-                <constraint firstItem="B0N-ND-2kb" firstAttribute="trailing" secondItem="WeD-so-1q4" secondAttribute="trailing" id="9Ik-4T-b0J"/>
+                <constraint firstItem="B0N-ND-2kb" firstAttribute="trailing" secondItem="WeD-so-1q4" secondAttribute="trailing" priority="999" id="9Ik-4T-b0J"/>
                 <constraint firstItem="B0N-ND-2kb" firstAttribute="top" secondItem="YP7-6a-xZ6" secondAttribute="bottom" id="N9s-Fa-sfO"/>
                 <constraint firstItem="YP7-6a-xZ6" firstAttribute="top" secondItem="WeD-so-1q4" secondAttribute="top" id="SSa-Zb-0jT"/>
                 <constraint firstItem="WeD-so-1q4" firstAttribute="bottom" secondItem="B0N-ND-2kb" secondAttribute="bottom" id="XEt-fe-MaR"/>


### PR DESCRIPTION
Added note saving binding so the note list is refreshed on successful save;
Disable the submit note button while saving to prevent multiple requests;
After saving/uploading a note, the view is reset so the user won't accidentally send another note on the iPad;
Updating the question list states on question answered (because the list is always visibile on the iPad);
Fixed a constraint conlict in the time picker;
Bumped version