### PR TITLE
Dark mode support

### DIFF
--- a/MonitorizareVot.xcodeproj/project.pbxproj
+++ b/MonitorizareVot.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		18914E8F23873400006BE3D1 /* ColorSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18914E8E23873400006BE3D1 /* ColorSchema.swift */; };
 		18914E92238734EF006BE3D1 /* StandardColorSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18914E91238734EF006BE3D1 /* StandardColorSchema.swift */; };
+		18914E9423873FD8006BE3D1 /* DarkModeColorSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18914E9323873FD8006BE3D1 /* DarkModeColorSchema.swift */; };
+		18914E96238741F2006BE3D1 /* ColorSchemaSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18914E95238741F1006BE3D1 /* ColorSchemaSelectionTests.swift */; };
 		271595B521465EBA00BECC9C /* String+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271595B421465EBA00BECC9C /* String+Localization.swift */; };
 		27EDBD2221465D190060DB8A /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27EDBD2421465D190060DB8A /* Localizable.strings */; };
 		28104130236B5CA500B7422C /* AttachNoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2810412E236B5CA500B7422C /* AttachNoteViewController.swift */; };
@@ -140,6 +142,8 @@
 		17220BEAAF40F0C9F0CE43ED /* Pods_MonitorizareVot.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MonitorizareVot.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		18914E8E23873400006BE3D1 /* ColorSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSchema.swift; sourceTree = "<group>"; };
 		18914E91238734EF006BE3D1 /* StandardColorSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardColorSchema.swift; sourceTree = "<group>"; };
+		18914E9323873FD8006BE3D1 /* DarkModeColorSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkModeColorSchema.swift; sourceTree = "<group>"; };
+		18914E95238741F1006BE3D1 /* ColorSchemaSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSchemaSelectionTests.swift; sourceTree = "<group>"; };
 		271595B421465EBA00BECC9C /* String+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Localization.swift"; sourceTree = "<group>"; };
 		27EDBD2621465D290060DB8A /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		27EDBD2821465D480060DB8A /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -313,6 +317,7 @@
 			children = (
 				18914E8E23873400006BE3D1 /* ColorSchema.swift */,
 				18914E91238734EF006BE3D1 /* StandardColorSchema.swift */,
+				18914E9323873FD8006BE3D1 /* DarkModeColorSchema.swift */,
 			);
 			name = ColorSchemes;
 			sourceTree = "<group>";
@@ -618,6 +623,7 @@
 				EF4BD3A11D9D08DE0042BEC7 /* MonitorizareVotTests.m */,
 				EF4BD3A31D9D08DE0042BEC7 /* Info.plist */,
 				2817EA2B2358FAB60029AD4C /* MonitorizareVotTests-Bridging-Header.h */,
+				18914E95238741F1006BE3D1 /* ColorSchemaSelectionTests.swift */,
 			);
 			path = MonitorizareVotTests;
 			sourceTree = "<group>";
@@ -1034,6 +1040,7 @@
 				28104140236C3A4900B7422C /* Formatters.swift in Sources */,
 				281A4B87236CC625001AD277 /* DropdownButton.swift in Sources */,
 				18914E8F23873400006BE3D1 /* ColorSchema.swift in Sources */,
+				18914E9423873FD8006BE3D1 /* DarkModeColorSchema.swift in Sources */,
 				28E72458233F58100096454D /* SectionDetailsViewModel.swift in Sources */,
 				28104139236B5DEF00B7422C /* NoteViewModel.swift in Sources */,
 				28A4B776237364FE00E6D2A8 /* RemoteConfigManager.swift in Sources */,
@@ -1085,6 +1092,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2817EA2D2358FAB60029AD4C /* APITests.swift in Sources */,
+				18914E96238741F2006BE3D1 /* ColorSchemaSelectionTests.swift in Sources */,
 				EF4BD3A21D9D08DE0042BEC7 /* MonitorizareVotTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MonitorizareVot.xcodeproj/project.pbxproj
+++ b/MonitorizareVot.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		18914E8F23873400006BE3D1 /* ColorSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18914E8E23873400006BE3D1 /* ColorSchema.swift */; };
+		18914E92238734EF006BE3D1 /* StandardColorSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18914E91238734EF006BE3D1 /* StandardColorSchema.swift */; };
 		271595B521465EBA00BECC9C /* String+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271595B421465EBA00BECC9C /* String+Localization.swift */; };
 		27EDBD2221465D190060DB8A /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27EDBD2421465D190060DB8A /* Localizable.strings */; };
 		28104130236B5CA500B7422C /* AttachNoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2810412E236B5CA500B7422C /* AttachNoteViewController.swift */; };
@@ -136,6 +138,8 @@
 
 /* Begin PBXFileReference section */
 		17220BEAAF40F0C9F0CE43ED /* Pods_MonitorizareVot.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MonitorizareVot.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		18914E8E23873400006BE3D1 /* ColorSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSchema.swift; sourceTree = "<group>"; };
+		18914E91238734EF006BE3D1 /* StandardColorSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardColorSchema.swift; sourceTree = "<group>"; };
 		271595B421465EBA00BECC9C /* String+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Localization.swift"; sourceTree = "<group>"; };
 		27EDBD2621465D290060DB8A /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		27EDBD2821465D480060DB8A /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -302,6 +306,15 @@
 				F0644FE9EC6A7ABF8A6EE0DC /* Pods-MonitorizareVotUITests.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		18914E9023873418006BE3D1 /* ColorSchemes */ = {
+			isa = PBXGroup;
+			children = (
+				18914E8E23873400006BE3D1 /* ColorSchema.swift */,
+				18914E91238734EF006BE3D1 /* StandardColorSchema.swift */,
+			);
+			name = ColorSchemes;
 			sourceTree = "<group>";
 		};
 		27EDBD15214658CD0060DB8A /* Localizations */ = {
@@ -523,6 +536,7 @@
 				67EE98C922A296B1006E4762 /* Logging */,
 				E7E1F2C51DDB59C800CE52FC /* API */,
 				EFB9AD1B1DEA1039008C1035 /* DBHandlers */,
+				18914E9023873418006BE3D1 /* ColorSchemes */,
 				E7E8EB4A1DDB7344009EBE01 /* UIColor+Presets.swift */,
 				28E7245E233F5E620096454D /* UIImage+Utils.swift */,
 				28E72465233F67280096454D /* Configuration.swift */,
@@ -759,22 +773,22 @@
 				TargetAttributes = {
 					EF4BD3801D9D08DE0042BEC7 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = 442AHZGZ2T;
+						DevelopmentTeam = "\"\"";
 						LastSwiftMigration = 0810;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					EF4BD39C1D9D08DE0042BEC7 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = 442AHZGZ2T;
+						DevelopmentTeam = "\"\"";
 						LastSwiftMigration = 1100;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 						TestTargetID = EF4BD3801D9D08DE0042BEC7;
 					};
 					EF4BD3A71D9D08DE0042BEC7 = {
 						CreatedOnToolsVersion = 8.0;
 						DevelopmentTeam = P2EQL76LN6;
 						LastSwiftMigration = 0810;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 						TestTargetID = EF4BD3801D9D08DE0042BEC7;
 					};
 				};
@@ -1012,12 +1026,14 @@
 				2810413C236C2EC300B7422C /* NoteHistoryTableCell.swift in Sources */,
 				28104142236C3FD500B7422C /* Alerts.swift in Sources */,
 				28C3639523646D480084065C /* DefaultTableHeader.swift in Sources */,
+				18914E92238734EF006BE3D1 /* StandardColorSchema.swift in Sources */,
 				EF3DC3951DE9DB02006F9D73 /* CoreDataInitialiser.swift in Sources */,
 				2817EA1C2358F2140029AD4C /* PreferencesManager.swift in Sources */,
 				F553E3BB1DF9D67A000D0902 /* Question+CoreDataClass.swift in Sources */,
 				281A4B82236CBD30001AD277 /* SectionPickerViewController.swift in Sources */,
 				28104140236C3A4900B7422C /* Formatters.swift in Sources */,
 				281A4B87236CC625001AD277 /* DropdownButton.swift in Sources */,
+				18914E8F23873400006BE3D1 /* ColorSchema.swift in Sources */,
 				28E72458233F58100096454D /* SectionDetailsViewModel.swift in Sources */,
 				28104139236B5DEF00B7422C /* NoteViewModel.swift in Sources */,
 				28A4B776237364FE00E6D2A8 /* RemoteConfigManager.swift in Sources */,

--- a/MonitorizareVot.xcodeproj/project.pbxproj
+++ b/MonitorizareVot.xcodeproj/project.pbxproj
@@ -779,22 +779,22 @@
 				TargetAttributes = {
 					EF4BD3801D9D08DE0042BEC7 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = "\"\"";
+						DevelopmentTeam = 442AHZGZ2T;
 						LastSwiftMigration = 0810;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 					EF4BD39C1D9D08DE0042BEC7 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = "\"\"";
+						DevelopmentTeam = 442AHZGZ2T;
 						LastSwiftMigration = 1100;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 						TestTargetID = EF4BD3801D9D08DE0042BEC7;
 					};
 					EF4BD3A71D9D08DE0042BEC7 = {
 						CreatedOnToolsVersion = 8.0;
 						DevelopmentTeam = P2EQL76LN6;
 						LastSwiftMigration = 0810;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 						TestTargetID = EF4BD3801D9D08DE0042BEC7;
 					};
 				};

--- a/MonitorizareVot/ActionButton.swift
+++ b/MonitorizareVot/ActionButton.swift
@@ -16,6 +16,15 @@ class ActionButton: UIButton {
         setup()
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                setup()
+            }
+        }
+    }
+    
     override func prepareForInterfaceBuilder() {
         super.prepareForInterfaceBuilder()
         setup()

--- a/MonitorizareVot/ActionButton.swift
+++ b/MonitorizareVot/ActionButton.swift
@@ -22,13 +22,13 @@ class ActionButton: UIButton {
     }
     
     fileprivate func setup() {
-        setBackgroundImage(UIImage.from(color: .actionButtonBackground), for: .normal)
-        setBackgroundImage(UIImage.from(color: .actionButtonBackgroundHighlighted), for: .highlighted)
-        setBackgroundImage(UIImage.from(color: .actionButtonBackgroundDisabled), for: .disabled)
+        setBackgroundImage(UIImage.from(color: UIColor.colorSchema.actionButtonBackground), for: .normal)
+        setBackgroundImage(UIImage.from(color: UIColor.colorSchema.actionButtonBackgroundHighlighted), for: .highlighted)
+        setBackgroundImage(UIImage.from(color: UIColor.colorSchema.actionButtonBackgroundDisabled), for: .disabled)
 
-        setTitleColor(.actionButtonForeground, for: .normal)
-        setTitleColor(.actionButtonForeground, for: .highlighted)
-        setTitleColor(.actionButtonForegroundDisabled, for: .disabled)
+        setTitleColor(UIColor.colorSchema.actionButtonForeground, for: .normal)
+        setTitleColor(UIColor.colorSchema.actionButtonForeground, for: .highlighted)
+        setTitleColor(UIColor.colorSchema.actionButtonForegroundDisabled, for: .disabled)
 
         tintColor = .clear
         

--- a/MonitorizareVot/AppDelegate.swift
+++ b/MonitorizareVot/AppDelegate.swift
@@ -91,9 +91,9 @@ extension AppDelegate {
     }
     
     fileprivate func configureAppearance() {
-        UINavigationBar.appearance().tintColor = UIColor.navigationBarTint
-        UINavigationBar.appearance().backgroundColor = .navigationBarBackground
-        UINavigationBar.appearance().barTintColor = .navigationBarBackground
+        UINavigationBar.appearance().tintColor = UIColor.colorSchema.navigationBarTint
+        UINavigationBar.appearance().backgroundColor = UIColor.colorSchema.navigationBarBackground
+        UINavigationBar.appearance().barTintColor = UIColor.colorSchema.navigationBarBackground
     }
     
     fileprivate func setRootViewController() {

--- a/MonitorizareVot/AttachButton.swift
+++ b/MonitorizareVot/AttachButton.swift
@@ -16,6 +16,15 @@ class AttachButton: UIButton {
         setup()
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                setup()
+            }
+        }
+    }
+    
     override func prepareForInterfaceBuilder() {
         super.prepareForInterfaceBuilder()
         setup()

--- a/MonitorizareVot/AttachButton.swift
+++ b/MonitorizareVot/AttachButton.swift
@@ -22,12 +22,12 @@ class AttachButton: UIButton {
     }
     
     fileprivate func setup() {
-        setBackgroundImage(UIImage.from(color: .attachButtonBackground), for: .normal)
-        setBackgroundImage(UIImage.from(color: .attachButtonBackgroundHighlighted), for: .highlighted)
+        setBackgroundImage(UIImage.from(color: UIColor.colorSchema.attachButtonBackground), for: .normal)
+        setBackgroundImage(UIImage.from(color: UIColor.colorSchema.attachButtonBackgroundHighlighted), for: .highlighted)
 
-        setTitleColor(.attachButtonForeground, for: .normal)
-        setTitleColor(.attachButtonForeground, for: .highlighted)
-        setTitleColor(.attachButtonForegroundDisabled, for: .disabled)
+        setTitleColor(UIColor.colorSchema.attachButtonForeground, for: .normal)
+        setTitleColor(UIColor.colorSchema.attachButtonForeground, for: .highlighted)
+        setTitleColor(UIColor.colorSchema.attachButtonForegroundDisabled, for: .disabled)
 
         tintColor = .clear
         

--- a/MonitorizareVot/ChooserButton.swift
+++ b/MonitorizareVot/ChooserButton.swift
@@ -22,15 +22,15 @@ class ChooserButton: UIButton {
     }
     
     fileprivate func setup() {
-        setBackgroundImage(UIImage.from(color: .chooserButtonBackground), for: .normal)
-        setBackgroundImage(UIImage.from(color: .chooserButtonSelectedBackground), for: .selected)
-        setBackgroundImage(UIImage.from(color: UIColor.chooserButtonSelectedBackground.withAlphaComponent(0.5)), for: .highlighted)
-        setBackgroundImage(UIImage.from(color: .chooserButtonSelectedBackground), for: [.selected, .highlighted])
+        setBackgroundImage(UIImage.from(color: UIColor.colorSchema.chooserButtonBackground), for: .normal)
+        setBackgroundImage(UIImage.from(color: UIColor.colorSchema.chooserButtonSelectedBackground), for: .selected)
+        setBackgroundImage(UIImage.from(color: UIColor.colorSchema.chooserButtonSelectedBackground.withAlphaComponent(0.5)), for: .highlighted)
+        setBackgroundImage(UIImage.from(color: UIColor.colorSchema.chooserButtonSelectedBackground), for: [.selected, .highlighted])
         
-        setTitleColor(.defaultText, for: .normal)
-        setTitleColor(.defaultText, for: .selected)
-        setTitleColor(.defaultText, for: .highlighted)
-        setTitleColor(.defaultText, for: [.highlighted, .selected])
+        setTitleColor(UIColor.colorSchema.defaultText, for: .normal)
+        setTitleColor(UIColor.colorSchema.defaultText, for: .selected)
+        setTitleColor(UIColor.colorSchema.defaultText, for: .highlighted)
+        setTitleColor(UIColor.colorSchema.defaultText, for: [.highlighted, .selected])
         
         imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 16)
         titleLabel?.minimumScaleFactor = 0.5
@@ -42,7 +42,7 @@ class ChooserButton: UIButton {
         layer.masksToBounds = true
         layer.cornerRadius = Configuration.buttonCornerRadius
         layer.borderWidth = 1
-        layer.borderColor = UIColor.chooserButtonBorder.cgColor
+        layer.borderColor = UIColor.colorSchema.chooserButtonBorder.cgColor
         
         titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: .semibold)
     }

--- a/MonitorizareVot/ChooserButton.swift
+++ b/MonitorizareVot/ChooserButton.swift
@@ -16,6 +16,15 @@ class ChooserButton: UIButton {
         setup()
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                setup()
+            }
+        }
+    }
+    
     override func prepareForInterfaceBuilder() {
         super.prepareForInterfaceBuilder()
         setup()
@@ -25,12 +34,8 @@ class ChooserButton: UIButton {
         setBackgroundImage(UIImage.from(color: UIColor.colorSchema.chooserButtonBackground), for: .normal)
         setBackgroundImage(UIImage.from(color: UIColor.colorSchema.chooserButtonSelectedBackground), for: .selected)
         setBackgroundImage(UIImage.from(color: UIColor.colorSchema.chooserButtonSelectedBackground.withAlphaComponent(0.5)), for: .highlighted)
-        setBackgroundImage(UIImage.from(color: UIColor.colorSchema.chooserButtonSelectedBackground), for: [.selected, .highlighted])
         
-        setTitleColor(UIColor.colorSchema.defaultText, for: .normal)
-        setTitleColor(UIColor.colorSchema.defaultText, for: .selected)
-        setTitleColor(UIColor.colorSchema.defaultText, for: .highlighted)
-        setTitleColor(UIColor.colorSchema.defaultText, for: [.highlighted, .selected])
+        setTitleColor(UIColor.colorSchema.defaultText, for: [.normal, .highlighted, .selected])
         
         imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 16)
         titleLabel?.minimumScaleFactor = 0.5

--- a/MonitorizareVot/CollectionCells/QuestionCollectionCell.swift
+++ b/MonitorizareVot/CollectionCells/QuestionCollectionCell.swift
@@ -37,7 +37,7 @@ class QuestionCollectionCell: UICollectionViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        container.layer.shadowColor = UIColor.cardDarkerShadow.cgColor
+        container.layer.shadowColor = UIColor.colorSchema.cardDarkerShadow.cgColor
         container.layer.shadowRadius = Configuration.shadowRadius
         container.layer.shadowOpacity = 1
         container.layer.shadowOffset = .zero

--- a/MonitorizareVot/ColorSchema.swift
+++ b/MonitorizareVot/ColorSchema.swift
@@ -1,0 +1,44 @@
+//
+//  ColorSchema.swift
+//  MonitorizareVot
+//
+//  Created by Alex Ioja-Yang on 21/11/2019.
+//  Copyright © 2019 Code4Ro. All rights reserved.
+//
+
+import UIKit
+
+protocol ColorSchema {
+    static var navigationBarBackground: UIColor { get }
+    static var navigationBarTint: UIColor { get }
+
+    static var appBackground: UIColor { get }
+    static var headerBackground: UIColor { get }
+    static var defaultText: UIColor { get }
+
+    static var formNameText: UIColor { get }
+
+    static var chooserButtonBorder: UIColor { get }
+    static var chooserButtonBackground: UIColor { get }
+    static var chooserButtonSelectedBackground: UIColor { get }
+
+    static var actionButtonForeground: UIColor { get }
+    static var actionButtonForegroundDisabled: UIColor { get }
+    static var actionButtonBackground: UIColor { get }
+    static var actionButtonBackgroundHighlighted: UIColor { get }
+    static var actionButtonBackgroundDisabled: UIColor { get }
+
+    static var attachButtonForeground: UIColor { get }
+    static var attachButtonForegroundDisabled: UIColor { get }
+    static var attachButtonBackground: UIColor { get }
+    static var attachButtonBackgroundHighlighted: UIColor { get }
+
+    static var cardBackground: UIColor { get }
+    static var cardBackgroundSelected: UIColor { get }
+    static var cardShadow: UIColor { get }
+    static var cardDarkerShadow: UIColor { get }
+    static var tableSectionHeaderBg: UIColor { get }
+
+    static var textViewContainerBorder: UIColor { get }
+    static var textViewContainerBg: UIColor { get }
+}

--- a/MonitorizareVot/DarkModeColorSchema.swift
+++ b/MonitorizareVot/DarkModeColorSchema.swift
@@ -1,0 +1,46 @@
+//
+//  DarkModeColorSchema.swift
+//  MonitorizareVot
+//
+//  Created by Alex Ioja-Yang on 21/11/2019.
+//  Copyright © 2019 Code4Ro. All rights reserved.
+//
+
+import UIKit
+
+struct DarkModeColorSchema: ColorSchema {
+    static let navigationBarBackground = UIColor(hexCode: 0xFFCC00)
+    static let navigationBarTint = UIColor(hexCode: 0x333E48)
+    
+    // Important: We need to make these checks until we have the minimum deployment set to iOS 11
+
+    static var appBackground = UIColor(hexCode: 0xFAFAFA)
+    static var headerBackground = UIColor(hexCode: 0xFFFFFF)
+    static var defaultText = UIColor(hexCode: 0x333E48)
+
+    static var formNameText = UIColor.black
+
+    static var chooserButtonBorder = UIColor(hexCode: 0x333E48).withAlphaComponent(0.3)
+    static var chooserButtonBackground = UIColor.clear
+    static var chooserButtonSelectedBackground = navigationBarBackground
+
+    static var actionButtonForeground = UIColor(hexCode: 0x81175C)
+    static var actionButtonForegroundDisabled = actionButtonForeground.withAlphaComponent(0.4)
+    static var actionButtonBackground = actionButtonForeground.withAlphaComponent(0.065)
+    static var actionButtonBackgroundHighlighted = actionButtonForeground.withAlphaComponent(0.14)
+    static var actionButtonBackgroundDisabled = actionButtonForeground.withAlphaComponent(0.026)
+
+    static var attachButtonForeground = actionButtonForeground
+    static var attachButtonForegroundDisabled = attachButtonForeground.withAlphaComponent(0.4)
+    static var attachButtonBackground = UIColor.clear
+    static var attachButtonBackgroundHighlighted = attachButtonForeground.withAlphaComponent(0.07)
+
+    static var cardBackground = UIColor.white
+    static var cardBackgroundSelected = chooserButtonSelectedBackground
+    static var cardShadow = UIColor.black.withAlphaComponent(0.03)
+    static var cardDarkerShadow = UIColor.black.withAlphaComponent(0.12)
+    static var tableSectionHeaderBg = UIColor(hexCode: 0xEEEDED)
+
+    static var textViewContainerBorder = UIColor(hexCode: 0xDDDDDD)
+    static var textViewContainerBg = UIColor(hexCode: 0xFCFCFC)
+}

--- a/MonitorizareVot/DropdownButton.swift
+++ b/MonitorizareVot/DropdownButton.swift
@@ -28,7 +28,7 @@ class DropdownButton: UIButton {
     fileprivate lazy var label: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 16, weight: .regular)
-        label.textColor = .defaultText
+        label.textColor = UIColor.colorSchema.defaultText
         return label
     }()
     
@@ -49,10 +49,10 @@ class DropdownButton: UIButton {
     fileprivate func update() {
         if let value = value,
             value.trimmingCharacters(in: .whitespacesAndNewlines).count > 0 {
-            label.textColor = .defaultText
+            label.textColor = UIColor.colorSchema.defaultText
             label.text = value
         } else {
-            label.textColor = UIColor.defaultText.withAlphaComponent(0.5)
+            label.textColor = UIColor.colorSchema.defaultText.withAlphaComponent(0.5)
             label.text = placeholder
         }
     }
@@ -79,7 +79,7 @@ class DropdownButton: UIButton {
         layer.masksToBounds = true
         layer.cornerRadius = Configuration.buttonCornerRadius
         layer.borderWidth = 1
-        layer.borderColor = UIColor.textViewContainerBorder.cgColor
+        layer.borderColor = UIColor.colorSchema.textViewContainerBorder.cgColor
     }
 
 

--- a/MonitorizareVot/DropdownButton.swift
+++ b/MonitorizareVot/DropdownButton.swift
@@ -41,6 +41,16 @@ class DropdownButton: UIButton {
         setup()
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                update()
+                setup()
+            }
+        }
+    }
+    
     override func prepareForInterfaceBuilder() {
         super.prepareForInterfaceBuilder()
         setup()

--- a/MonitorizareVot/Form/AttachNoteViewController.swift
+++ b/MonitorizareVot/Form/AttachNoteViewController.swift
@@ -63,17 +63,17 @@ class AttachNoteViewController: UIViewController {
     fileprivate func configureAppearance() {
         cardContainer.layer.masksToBounds = true
         cardContainer.layer.cornerRadius = Configuration.buttonCornerRadius
-        outerContainer.layer.shadowColor = UIColor.cardDarkerShadow.cgColor
+        outerContainer.layer.shadowColor = UIColor.colorSchema.cardDarkerShadow.cgColor
         outerContainer.layer.shadowOffset = .zero
         outerContainer.layer.shadowRadius = Configuration.shadowRadius
         outerContainer.layer.shadowOpacity = Configuration.shadowOpacity
-        titleLabel.textColor = .defaultText
+        titleLabel.textColor = UIColor.colorSchema.defaultText
         textViewContainer.layer.borderWidth = 1
-        textViewContainer.layer.borderColor = UIColor.textViewContainerBorder.cgColor
+        textViewContainer.layer.borderColor = UIColor.colorSchema.textViewContainerBorder.cgColor
         textViewContainer.layer.cornerRadius = Configuration.buttonCornerRadius
         textView.textContainerInset = UIEdgeInsets(top: 13, left: 10, bottom: 13, right: 10)
         textView.contentOffset = .zero
-        textView.textColor = .defaultText
+        textView.textColor = UIColor.colorSchema.defaultText
     }
     
     fileprivate func localize() {

--- a/MonitorizareVot/Form/AttachNoteViewController.swift
+++ b/MonitorizareVot/Form/AttachNoteViewController.swift
@@ -58,6 +58,15 @@ class AttachNoteViewController: UIViewController {
         updateInterface()
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                configureAppearance()
+            }
+        }
+    }
+    
     // MARK: - Config
     
     fileprivate func configureAppearance() {

--- a/MonitorizareVot/Form/NoteViewController.swift
+++ b/MonitorizareVot/Form/NoteViewController.swift
@@ -64,6 +64,15 @@ class NoteViewController: MVViewController {
         }
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                historyTableView.reloadData()
+            }
+        }
+    }
+    
     fileprivate func configureTableView() {
         if #available(iOS 11.0, *) {
             historyTableView.contentInsetAdjustmentBehavior = .never

--- a/MonitorizareVot/Form/NoteViewController.swift
+++ b/MonitorizareVot/Form/NoteViewController.swift
@@ -116,7 +116,7 @@ class NoteViewController: MVViewController {
         options.addAction(UIAlertAction(title: "Cancel".localized, style: .cancel, handler: nil))
         options.popoverPresentationController?.sourceRect = sourceView.frame
         options.popoverPresentationController?.sourceView = sourceView.superview
-        options.view.tintColor = .navigationBarTint
+        options.view.tintColor = UIColor.colorSchema.navigationBarTint
         present(options, animated: true, completion: nil)
     }
     

--- a/MonitorizareVot/Form/QuestionListViewController.swift
+++ b/MonitorizareVot/Form/QuestionListViewController.swift
@@ -50,6 +50,15 @@ class QuestionListViewController: MVViewController {
         AppRouter.shared.resetDetailsPane()
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                tableView.reloadData()
+            }
+        }
+    }
+    
     // MARK: - Config
     
     fileprivate func configureTableView() {

--- a/MonitorizareVot/FormList/FormListViewController.swift
+++ b/MonitorizareVot/FormList/FormListViewController.swift
@@ -61,6 +61,15 @@ class FormListViewController: MVViewController {
         }
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                tableView.reloadData()
+            }
+        }
+    }
+    
     // MARK: - Config
     
     fileprivate func bindToUpdates() {

--- a/MonitorizareVot/Login/LoginViewController.swift
+++ b/MonitorizareVot/Login/LoginViewController.swift
@@ -37,6 +37,15 @@ class LoginViewController: MVViewController {
         updateInterface()
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                configureViews()
+            }
+        }
+    }
+    
     fileprivate func bindToUpdates() {
         model.onUpdate = { [weak self] in
             self?.updateInterface()

--- a/MonitorizareVot/Login/LoginViewController.swift
+++ b/MonitorizareVot/Login/LoginViewController.swift
@@ -45,17 +45,17 @@ class LoginViewController: MVViewController {
     
     fileprivate func configureViews() {
         outerCardContainer.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor).isActive = true
-        outerCardContainer.layer.shadowColor = UIColor.cardDarkerShadow.cgColor
+        outerCardContainer.layer.shadowColor = UIColor.colorSchema.cardDarkerShadow.cgColor
         outerCardContainer.layer.shadowOffset = .zero
         outerCardContainer.layer.shadowRadius = Configuration.shadowRadius
         outerCardContainer.layer.shadowOpacity = Configuration.shadowOpacity
         cardContainer.layer.cornerRadius = Configuration.buttonCornerRadius
-        cardContainer.backgroundColor = .cardBackground
+        cardContainer.backgroundColor = UIColor.colorSchema.cardBackground
         phoneContainer.layer.cornerRadius = Configuration.buttonCornerRadius
-        phoneContainer.layer.borderColor = UIColor.textViewContainerBorder.cgColor
+        phoneContainer.layer.borderColor = UIColor.colorSchema.textViewContainerBorder.cgColor
         phoneContainer.layer.borderWidth = 1
         codeContainer.layer.cornerRadius = Configuration.buttonCornerRadius
-        codeContainer.layer.borderColor = UIColor.textViewContainerBorder.cgColor
+        codeContainer.layer.borderColor = UIColor.colorSchema.textViewContainerBorder.cgColor
         codeContainer.layer.borderWidth = 1
     }
     

--- a/MonitorizareVot/PollingStation/SectionPickerViewController.swift
+++ b/MonitorizareVot/PollingStation/SectionPickerViewController.swift
@@ -59,8 +59,8 @@ class SectionPickerViewController: MVViewController {
         stationTextContainer.layer.masksToBounds = true
         stationTextContainer.layer.cornerRadius = Configuration.buttonCornerRadius
         stationTextContainer.layer.borderWidth = 1
-        stationTextContainer.layer.borderColor = UIColor.chooserButtonBorder.cgColor
-        stationTextField.textColor = .defaultText
+        stationTextContainer.layer.borderColor = UIColor.colorSchema.chooserButtonBorder.cgColor
+        stationTextField.textColor = UIColor.colorSchema.defaultText
         scrollView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor).isActive = true
     }
     

--- a/MonitorizareVot/PollingStation/SectionPickerViewController.swift
+++ b/MonitorizareVot/PollingStation/SectionPickerViewController.swift
@@ -52,6 +52,15 @@ class SectionPickerViewController: MVViewController {
         navigationController?.setNavigationBarHidden(false, animated: animated)
         updateInterface()
     }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                configureSubviews()
+            }
+        }
+    }
 
     // MARK: - Configuration
     

--- a/MonitorizareVot/SectionHUDViewController.swift
+++ b/MonitorizareVot/SectionHUDViewController.swift
@@ -33,12 +33,12 @@ class SectionHUDViewController: UIViewController {
     // MARK: - UI
     
     fileprivate func configureSubViews() {
-        view.backgroundColor = .headerBackground
+        view.backgroundColor = UIColor.colorSchema.headerBackground
         
-        let lighterTextColor = UIColor.defaultText.withAlphaComponent(0.5)
+        let lighterTextColor = UIColor.colorSchema.defaultText.withAlphaComponent(0.5)
         icon.tintColor = lighterTextColor
         titleLabel.textColor = lighterTextColor
-        changeButton.setTitleColor(.navigationBarBackground, for: .normal)
+        changeButton.setTitleColor(UIColor.colorSchema.navigationBarBackground, for: .normal)
     }
     
     fileprivate func configureTexts() {

--- a/MonitorizareVot/SectionHUDViewController.swift
+++ b/MonitorizareVot/SectionHUDViewController.swift
@@ -30,6 +30,15 @@ class SectionHUDViewController: UIViewController {
         configureTexts()
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                configureSubViews()
+            }
+        }
+    }
+    
     // MARK: - UI
     
     fileprivate func configureSubViews() {

--- a/MonitorizareVot/StandardColorSchema.swift
+++ b/MonitorizareVot/StandardColorSchema.swift
@@ -1,0 +1,46 @@
+//
+//  StandardColorSchema.swift
+//  MonitorizareVot
+//
+//  Created by Alex Ioja-Yang on 21/11/2019.
+//  Copyright © 2019 Code4Ro. All rights reserved.
+//
+
+import UIKit
+
+struct StandardColorSchema: ColorSchema {
+    static let navigationBarBackground = UIColor(hexCode: 0xFFCC00)
+    static let navigationBarTint = UIColor(hexCode: 0x333E48)
+    
+    // Important: We need to make these checks until we have the minimum deployment set to iOS 11
+
+    static var appBackground = UIColor(hexCode: 0xFAFAFA)
+    static var headerBackground = UIColor(hexCode: 0xFFFFFF)
+    static var defaultText = UIColor(hexCode: 0x333E48)
+
+    static var formNameText = UIColor.black
+
+    static var chooserButtonBorder = UIColor(hexCode: 0x333E48).withAlphaComponent(0.3)
+    static var chooserButtonBackground = UIColor.clear
+    static var chooserButtonSelectedBackground = navigationBarBackground
+
+    static var actionButtonForeground = UIColor(hexCode: 0x81175C)
+    static var actionButtonForegroundDisabled = actionButtonForeground.withAlphaComponent(0.4)
+    static var actionButtonBackground = actionButtonForeground.withAlphaComponent(0.065)
+    static var actionButtonBackgroundHighlighted = actionButtonForeground.withAlphaComponent(0.14)
+    static var actionButtonBackgroundDisabled = actionButtonForeground.withAlphaComponent(0.026)
+
+    static var attachButtonForeground = actionButtonForeground
+    static var attachButtonForegroundDisabled = attachButtonForeground.withAlphaComponent(0.4)
+    static var attachButtonBackground = UIColor.clear
+    static var attachButtonBackgroundHighlighted = attachButtonForeground.withAlphaComponent(0.07)
+
+    static var cardBackground = UIColor.white
+    static var cardBackgroundSelected = chooserButtonSelectedBackground
+    static var cardShadow = UIColor.black.withAlphaComponent(0.03)
+    static var cardDarkerShadow = UIColor.black.withAlphaComponent(0.12)
+    static var tableSectionHeaderBg = UIColor(hexCode: 0xEEEDED)
+
+    static var textViewContainerBorder = UIColor(hexCode: 0xDDDDDD)
+    static var textViewContainerBg = UIColor(hexCode: 0xFCFCFC)
+}

--- a/MonitorizareVot/TableCells/FormSetTableCell.swift
+++ b/MonitorizareVot/TableCells/FormSetTableCell.swift
@@ -35,7 +35,7 @@ class FormSetTableCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         clipsToBounds = false
-        outerCardContainer.layer.shadowColor = UIColor.cardShadow.cgColor
+        outerCardContainer.layer.shadowColor = UIColor.colorSchema.cardShadow.cgColor
         outerCardContainer.layer.shadowRadius = Configuration.shadowRadius
         outerCardContainer.layer.shadowOpacity = Configuration.shadowOpacity
         selectedBackgroundView = UIView(frame: .zero)
@@ -48,7 +48,7 @@ class FormSetTableCell: UITableViewCell {
     
     fileprivate func updateSelectionState(selected: Bool) {
         cardContainer.backgroundColor = selected ?
-            UIColor.cardBackgroundSelected : UIColor.cardBackground
+            UIColor.colorSchema.cardBackgroundSelected : UIColor.colorSchema.cardBackground
     }
     
     func update(withModel model: FormSetCellModel) {
@@ -67,7 +67,7 @@ class FormSetTableCell: UITableViewCell {
         let text = NSMutableAttributedString(string: model.title,
                                              attributes: [
                                                 .font: UIFont.systemFont(ofSize: 18, weight: .bold),
-                                                .foregroundColor: UIColor.formNameText,
+                                                .foregroundColor: UIColor.colorSchema.formNameText,
                                                 .paragraphStyle: paragraphStyle
                                              ])
         
@@ -75,7 +75,7 @@ class FormSetTableCell: UITableViewCell {
         text.append(NSAttributedString(string: codeText,
                                        attributes: [
                                         .font: UIFont.systemFont(ofSize: 18, weight: .regular),
-                                        .foregroundColor: UIColor.formNameText.withAlphaComponent(0.4),
+                                        .foregroundColor: UIColor.colorSchema.formNameText.withAlphaComponent(0.4),
                                         .paragraphStyle: paragraphStyle
                                        ]))
         
@@ -85,7 +85,7 @@ class FormSetTableCell: UITableViewCell {
     func updateAsNote() {
         iconView.image = UIImage(named: "icon-note-small")
         titleLabel.text = "Label_AddNote".localized
-        titleLabel.textColor = .formNameText
+        titleLabel.textColor = UIColor.colorSchema.formNameText
         answeredLabel.text = nil
         progressContainer.isHidden = true
         outerCardContainer.layoutIfNeeded()

--- a/MonitorizareVot/TableCells/NoteHistoryTableCell.swift
+++ b/MonitorizareVot/TableCells/NoteHistoryTableCell.swift
@@ -24,15 +24,15 @@ class NoteHistoryTableCell: UITableViewCell {
         selectedBackgroundView?.backgroundColor = .clear
         selectionStyle = .none
         outerContainer.backgroundColor = .clear
-        outerContainer.layer.shadowColor = UIColor.cardShadow.cgColor
+        outerContainer.layer.shadowColor = UIColor.colorSchema.cardShadow.cgColor
         outerContainer.layer.shadowOffset = .zero
         outerContainer.layer.shadowRadius = Configuration.shadowRadius
         outerContainer.layer.shadowOpacity = Configuration.shadowOpacity
         cardContainer.layer.cornerRadius = Configuration.buttonCornerRadius
         cardContainer.layer.masksToBounds = true
-        detailsLabel.textColor = .defaultText
-        dateLabel.textColor = .defaultText
-        cardContainer.backgroundColor = .cardBackground
+        detailsLabel.textColor = UIColor.colorSchema.defaultText
+        dateLabel.textColor = UIColor.colorSchema.defaultText
+        cardContainer.backgroundColor = UIColor.colorSchema.cardBackground
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/MonitorizareVot/TableCells/QuestionTableCell.swift
+++ b/MonitorizareVot/TableCells/QuestionTableCell.swift
@@ -23,11 +23,11 @@ class QuestionTableCell: UITableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        normalStateBg.backgroundColor = .cardBackground
+        normalStateBg.backgroundColor = UIColor.colorSchema.cardBackground
         normalStateBg.layer.cornerRadius = 4
-        selectedView.backgroundColor = .cardBackgroundSelected
+        selectedView.backgroundColor = UIColor.colorSchema.cardBackgroundSelected
         selectedView.layer.cornerRadius = 4
-        container.layer.shadowColor = UIColor.cardShadow.cgColor
+        container.layer.shadowColor = UIColor.colorSchema.cardShadow.cgColor
         container.layer.shadowRadius = Configuration.shadowRadius
         container.layer.shadowOpacity = Configuration.shadowOpacity
         selectedBackgroundView = UIView(frame: .zero)

--- a/MonitorizareVot/TableHeaders/DefaultTableHeader.swift
+++ b/MonitorizareVot/TableHeaders/DefaultTableHeader.swift
@@ -19,14 +19,14 @@ class DefaultTableHeader: UIView {
         backgroundColor = .clear
         
         let container = UIView(frame: CGRect(x: 0, y: 0, width: width, height: frame.height - 10))
-        container.backgroundColor = .tableSectionHeaderBg
+        container.backgroundColor = UIColor.colorSchema.tableSectionHeaderBg
         addSubview(container)
         
         titleLabel = UILabel(frame: container.bounds.inset(by: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)))
         container.addSubview(titleLabel)
 
         titleLabel.font = UIFont.boldSystemFont(ofSize: 12)
-        titleLabel.textColor = UIColor.defaultText.withAlphaComponent(0.3)
+        titleLabel.textColor = UIColor.colorSchema.defaultText.withAlphaComponent(0.3)
     }
     
     required init?(coder: NSCoder) {

--- a/MonitorizareVot/UIColor+Presets.swift
+++ b/MonitorizareVot/UIColor+Presets.swift
@@ -1,45 +1,13 @@
 //  Created by Code4Romania
 
-import Foundation
 import UIKit
 
 extension UIColor {
     
-    static let navigationBarBackground = UIColor(hexCode: 0xFFCC00)
-    static let navigationBarTint = UIColor(hexCode: 0x333E48)
+    static var colorSchema: ColorSchema.Type {
+        StandardColorSchema.self
+    }
     
-    // Important: We need to make these checks until we have the minimum deployment set to iOS 11
-
-    static var appBackground = UIColor(hexCode: 0xFAFAFA)
-    static var headerBackground = UIColor(hexCode: 0xFFFFFF)
-    static var defaultText = UIColor(hexCode: 0x333E48)
-
-    static var formNameText = UIColor.black
-
-    static var chooserButtonBorder = UIColor(hexCode: 0x333E48).withAlphaComponent(0.3)
-    static var chooserButtonBackground = UIColor.clear
-    static var chooserButtonSelectedBackground = navigationBarBackground
-
-    static var actionButtonForeground = UIColor(hexCode: 0x81175C)
-    static var actionButtonForegroundDisabled = actionButtonForeground.withAlphaComponent(0.4)
-    static var actionButtonBackground = actionButtonForeground.withAlphaComponent(0.065)
-    static var actionButtonBackgroundHighlighted = actionButtonForeground.withAlphaComponent(0.14)
-    static var actionButtonBackgroundDisabled = actionButtonForeground.withAlphaComponent(0.026)
-
-    static var attachButtonForeground = actionButtonForeground
-    static var attachButtonForegroundDisabled = attachButtonForeground.withAlphaComponent(0.4)
-    static var attachButtonBackground = UIColor.clear
-    static var attachButtonBackgroundHighlighted = attachButtonForeground.withAlphaComponent(0.07)
-
-    static var cardBackground = UIColor.white
-    static var cardBackgroundSelected = chooserButtonSelectedBackground
-    static var cardShadow = UIColor.black.withAlphaComponent(0.03)
-    static var cardDarkerShadow = UIColor.black.withAlphaComponent(0.12)
-    static var tableSectionHeaderBg = UIColor(hexCode: 0xEEEDED)
-
-    static var textViewContainerBorder = UIColor(hexCode: 0xDDDDDD)
-    static var textViewContainerBg = UIColor(hexCode: 0xFCFCFC)
-
     convenience init(hexCode: UInt32) {
         var alpha = hexCode >> 24 & 0xFF
         let red   = hexCode >> 16 & 0xFF

--- a/MonitorizareVot/UIColor+Presets.swift
+++ b/MonitorizareVot/UIColor+Presets.swift
@@ -5,7 +5,14 @@ import UIKit
 extension UIColor {
     
     static var colorSchema: ColorSchema.Type {
-        StandardColorSchema.self
+        // UserInterfaceStyle is available from iOS 12, but dark mode is only available from iOS 13.
+        if #available(iOS 13.0, *) {
+            return UIApplication.shared.keyWindow?.rootViewController?.traitCollection.userInterfaceStyle == .light ?
+                StandardColorSchema.self :
+                DarkModeColorSchema.self
+        } else {
+            return StandardColorSchema.self
+        }
     }
     
     convenience init(hexCode: UInt32) {

--- a/MonitorizareVot/UIColor+Presets.swift
+++ b/MonitorizareVot/UIColor+Presets.swift
@@ -7,7 +7,7 @@ extension UIColor {
     static var colorSchema: ColorSchema.Type {
         // UserInterfaceStyle is available from iOS 12, but dark mode is only available from iOS 13.
         if #available(iOS 13.0, *) {
-            return UIApplication.shared.keyWindow?.rootViewController?.traitCollection.userInterfaceStyle == .light ?
+            return UITraitCollection.current.userInterfaceStyle == .light ?
                 StandardColorSchema.self :
                 DarkModeColorSchema.self
         } else {

--- a/MonitorizareVot/Utility/EmptyDetailsViewController.swift
+++ b/MonitorizareVot/Utility/EmptyDetailsViewController.swift
@@ -21,8 +21,8 @@ class EmptyDetailsViewController: MVViewController {
     }
     
     fileprivate func configureView() {
-        view.backgroundColor = .appBackground
-        contentLabel.textColor = UIColor.defaultText.withAlphaComponent(0.4)
+        view.backgroundColor = UIColor.colorSchema.appBackground
+        contentLabel.textColor = UIColor.colorSchema.defaultText.withAlphaComponent(0.4)
         contentLabel.text = "Label_Empty".localized
     }
 

--- a/MonitorizareVot/Utility/GenericPickerViewController.swift
+++ b/MonitorizareVot/Utility/GenericPickerViewController.swift
@@ -44,9 +44,9 @@ class GenericPickerViewController: UIViewController {
     // MARK: - Config
     
     fileprivate func configureView() {
-        container.backgroundColor = .navigationBarBackground
-        container.tintColor = .navigationBarTint
-        container.layer.shadowColor = UIColor.cardDarkerShadow.cgColor
+        container.backgroundColor = UIColor.colorSchema.navigationBarBackground
+        container.tintColor = UIColor.colorSchema.navigationBarTint
+        container.layer.shadowColor = UIColor.colorSchema.cardDarkerShadow.cgColor
         container.layer.shadowRadius = Configuration.shadowRadius
         container.layer.shadowOffset = .zero
         container.layer.shadowOpacity = Configuration.shadowOpacity

--- a/MonitorizareVot/Utility/GenericPickerViewController.swift
+++ b/MonitorizareVot/Utility/GenericPickerViewController.swift
@@ -41,6 +41,15 @@ class GenericPickerViewController: UIViewController {
         picker.selectRow(model.selectedIndex, inComponent: 0, animated: false)
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                configureView()
+            }
+        }
+    }
+    
     // MARK: - Config
     
     fileprivate func configureView() {

--- a/MonitorizareVot/Utility/MVViewController.swift
+++ b/MonitorizareVot/Utility/MVViewController.swift
@@ -43,7 +43,7 @@ class MVViewController: UIViewController {
     }
     
     fileprivate func configureView() {
-        view.backgroundColor = .appBackground
+        view.backgroundColor = UIColor.colorSchema.appBackground
     }
     
     fileprivate func configureHeader() {

--- a/MonitorizareVot/Utility/MVViewController.swift
+++ b/MonitorizareVot/Utility/MVViewController.swift
@@ -38,6 +38,15 @@ class MVViewController: UIViewController {
         MVAnalytics.shared.log(event: .screen(name: String(describing: type(of: self))))
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                configureView()
+            }
+        }
+    }
+    
     fileprivate func configureBackButton() {
         self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
     }

--- a/MonitorizareVot/Utility/TimePickerViewController.swift
+++ b/MonitorizareVot/Utility/TimePickerViewController.swift
@@ -47,9 +47,9 @@ class TimePickerViewController: UIViewController {
     // MARK: - Config
     
     fileprivate func configureView() {
-        container.backgroundColor = .navigationBarBackground
-        container.tintColor = .navigationBarTint
-        container.layer.shadowColor = UIColor.cardDarkerShadow.cgColor
+        container.backgroundColor = UIColor.colorSchema.navigationBarBackground
+        container.tintColor = UIColor.colorSchema.navigationBarTint
+        container.layer.shadowColor = UIColor.colorSchema.cardDarkerShadow.cgColor
         container.layer.shadowRadius = Configuration.shadowRadius
         container.layer.shadowOffset = .zero
         container.layer.shadowOpacity = Configuration.shadowOpacity

--- a/MonitorizareVot/Utility/TimePickerViewController.swift
+++ b/MonitorizareVot/Utility/TimePickerViewController.swift
@@ -44,6 +44,15 @@ class TimePickerViewController: UIViewController {
         updateInterface()
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                configureView()
+            }
+        }
+    }
+    
     // MARK: - Config
     
     fileprivate func configureView() {

--- a/MonitorizareVotTests/APITests.swift
+++ b/MonitorizareVotTests/APITests.swift
@@ -67,7 +67,7 @@ class APITests: XCTestCase {
         let knownPin = correctPin
         let waiter = expectation(description: "Form Sets")
         sut?.login(withPhone: knownPhone, pin: knownPin, then: { error in
-            self.sut?.fetchFormSets(then: { (sets, error) in
+            self.sut?.fetchForms(diaspora: false, then: { sets, error in
                 XCTAssertNil(error)
                 XCTAssertNotNil(sets)
                 XCTAssert(sets!.count > 0)
@@ -83,7 +83,7 @@ class APITests: XCTestCase {
         let knownPin = correctPin
         let waiter = expectation(description: "Forms")
         sut?.login(withPhone: knownPhone, pin: knownPin, then: { error in
-            self.sut?.fetchForms(inSet: 1, then: { (forms, error) in
+            self.sut?.fetchForm(withId: 1, then: { (forms, error) in
                 XCTAssertNil(error)
                 XCTAssertNotNil(forms)
                 XCTAssert(forms!.count > 0)

--- a/MonitorizareVotTests/ColorSchemaSelectionTests.swift
+++ b/MonitorizareVotTests/ColorSchemaSelectionTests.swift
@@ -13,14 +13,14 @@ class ColorSchemaSelectionTests: XCTestCase {
     
     override func tearDown() {
         if #available(iOS 13.0, *) {
-            UIApplication.shared.keyWindow?.rootViewController?.overrideUserInterfaceStyle = .dark
+            UITraitCollection.current = UITraitCollection(userInterfaceStyle: .dark)
         }
         super.tearDown()
     }
     
     func testLightInterfaceStyle() {
         if #available(iOS 13.0, *) {
-            UIApplication.shared.keyWindow?.rootViewController?.overrideUserInterfaceStyle = .light
+            UITraitCollection.current = UITraitCollection(userInterfaceStyle: .light)
             XCTAssertTrue(UIColor.colorSchema is StandardColorSchema.Type)
         } else {
             XCTFail("Run tests on latest iOS version to ensure compatibility")
@@ -29,7 +29,7 @@ class ColorSchemaSelectionTests: XCTestCase {
     
     func testDarkInterfaceStyle() {
         if #available(iOS 13.0, *) {
-            UIApplication.shared.keyWindow?.rootViewController?.overrideUserInterfaceStyle = .dark
+            UITraitCollection.current = UITraitCollection(userInterfaceStyle: .dark)
             XCTAssertTrue(UIColor.colorSchema is DarkModeColorSchema.Type)
         } else {
             XCTFail("Run tests on latest iOS version to ensure compatibility")
@@ -38,7 +38,7 @@ class ColorSchemaSelectionTests: XCTestCase {
     
     func testUnspecifiedInterfaceStyle() {
         if #available(iOS 13.0, *) {
-            UIApplication.shared.keyWindow?.rootViewController?.overrideUserInterfaceStyle = .unspecified
+            UITraitCollection.current = UITraitCollection(userInterfaceStyle: .unspecified)
             XCTAssertTrue(UIColor.colorSchema is StandardColorSchema.Type)
         } else {
             XCTFail("Run tests on latest iOS version to ensure compatibility")

--- a/MonitorizareVotTests/ColorSchemaSelectionTests.swift
+++ b/MonitorizareVotTests/ColorSchemaSelectionTests.swift
@@ -1,0 +1,48 @@
+//
+//  ColorSchemaSelectionTests.swift
+//  MonitorizareVotTests
+//
+//  Created by Alex Ioja-Yang on 21/11/2019.
+//  Copyright © 2019 Code4Ro. All rights reserved.
+//
+
+import XCTest
+@testable import MonitorizareVot
+
+class ColorSchemaSelectionTests: XCTestCase {
+    
+    override func tearDown() {
+        if #available(iOS 13.0, *) {
+            UIApplication.shared.keyWindow?.rootViewController?.overrideUserInterfaceStyle = .dark
+        }
+        super.tearDown()
+    }
+    
+    func testLightInterfaceStyle() {
+        if #available(iOS 13.0, *) {
+            UIApplication.shared.keyWindow?.rootViewController?.overrideUserInterfaceStyle = .light
+            XCTAssertTrue(UIColor.colorSchema is StandardColorSchema.Type)
+        } else {
+            XCTFail("Run tests on latest iOS version to ensure compatibility")
+        }
+    }
+    
+    func testDarkInterfaceStyle() {
+        if #available(iOS 13.0, *) {
+            UIApplication.shared.keyWindow?.rootViewController?.overrideUserInterfaceStyle = .dark
+            XCTAssertTrue(UIColor.colorSchema is DarkModeColorSchema.Type)
+        } else {
+            XCTFail("Run tests on latest iOS version to ensure compatibility")
+        }
+    }
+    
+    func testUnspecifiedInterfaceStyle() {
+        if #available(iOS 13.0, *) {
+            UIApplication.shared.keyWindow?.rootViewController?.overrideUserInterfaceStyle = .unspecified
+            XCTAssertTrue(UIColor.colorSchema is StandardColorSchema.Type)
+        } else {
+            XCTFail("Run tests on latest iOS version to ensure compatibility")
+        }
+    }
+    
+}


### PR DESCRIPTION
Closes [issue #80](https://github.com/code4romania/monitorizare-vot-ios/issues/80)

Redirected all the color requests via `colorSchema`, which can determine the colour schema to be used and what colour to be used. I preferred this approach as it can provide easy extensions, enabling different colour schemas to be created for user (customisation options or even for accessibility purposes - better contrast, supportive for colour blindness etc). It's also only requiring a single source of truth for the colour schema picking.

Added 3 unit tests to ensure the accurate schema is returned for all possible cases.

***

⚠️ ⚠️ 
Dark mode scheme is still identical to normal scheme. I'm still unable to fully test all the application and also would prefer that customisation to be done alongside a UI/UX person to confirm they're happy with results or be able to tweak before committing to specific colours.