### PR TITLE
Show No Internet Connection error early

### DIFF
--- a/MonitorizareVot/APIManager.swift
+++ b/MonitorizareVot/APIManager.swift
@@ -62,6 +62,11 @@ class APIManager: NSObject, APIManagerType {
     }()
     
     func login(withPhone phone: String, pin: String, then callback: @escaping (APIError?) -> Void) {
+        if let errorMessage = checkConnectionError() {
+            callback(.generic(reason: errorMessage))
+            return
+        }
+        
         let url = ApiURL.login.url()
         let udid = AccountManager.shared.udid
         let request = LoginRequest(user: phone, password: pin, uniqueId: udid)
@@ -196,6 +201,11 @@ class APIManager: NSObject, APIManagerType {
     }
     
     func upload(pollingStation: UpdatePollingStationRequest, then callback: @escaping (APIError?) -> Void) {
+        if let errorMessage = checkConnectionError() {
+            callback(.generic(reason: errorMessage))
+            return
+        }
+        
         let url = ApiURL.pollingStation.url()
         let auth = authorizationHeaders()
         let headers = requestHeaders(withAuthHeaders: auth)
@@ -273,6 +283,10 @@ class APIManager: NSObject, APIManagerType {
                     callback(.incorrectFormat(reason: "Unknown reason (code: \(response.response?.statusCode ?? -1))"))
                 }
         }
+    }
+    
+    private func checkConnectionError() -> String? {
+        ReachabilityManager.shared.isReachable ? nil : "Error.InternetConnection".localized
     }
     
 }

--- a/MonitorizareVot/Base.lproj/Localizable.strings
+++ b/MonitorizareVot/Base.lproj/Localizable.strings
@@ -61,6 +61,7 @@
 "Error.UploadNoteFailed" = "We couldn't upload your note. We will retry later.";
 "Error.SelectCountyFirst" = "Please select your county / district first.";
 "Error.IncorrectStationNumber" = "Incorrect station number. Please double check the county and provided section number";
+"Error.InternetConnection" = "You need an internet connection to continue. Please check your internet connection.";
 
 "Info.DataNotSyncronised" = "It appears that some of the questions have not been syncronised. Tap the button below to send the answers again";
 

--- a/MonitorizareVot/ro.lproj/Localizable.strings
+++ b/MonitorizareVot/ro.lproj/Localizable.strings
@@ -61,6 +61,7 @@
 "Error.UploadNoteFailed" = "Nu am reușit să trimitem la server nota. Vom încerca mai târziu.";
 "Error.SelectCountyFirst" = "Te rugăm să alegi județul/sectorul pentru a putea alege secția";
 "Error.IncorrectStationNumber" = "Număr secție incorect. Te rugăm să verifici corectitudinea combinației județ - număr secție";
+"Error.InternetConnection" = "Ai nevoie de o conexiune la internet pentru a te conecta!";
 
 "Info.DataNotSyncronised" = "Se pare că unele răspunsuri nu au fost sincronizate cu serverul. Apasă butonul acesta pentru a le retrimite";
 


### PR DESCRIPTION
Closes [Issue #177](https://github.com/code4romania/monitorizare-vot-ios/issues/177)

Insert a quick check for internet connection, which generates a message and each client request will convert that error message into its specific error. Integrates with current error handling callbacks, to avoid going into creating a toast view and complicating the PR.

I still haven't had time to see why I can't login, so I haven't tested the second API request failure, only the login.