### PR TITLE
Updates to counties API

### DIFF
--- a/MonitorizareVot/APIManager.swift
+++ b/MonitorizareVot/APIManager.swift
@@ -17,7 +17,7 @@ protocol APIManagerType: NSObject {
                then callback: @escaping (APIError?) -> Void)
     func sendPushToken(withToken token: String,
                        then callback: @escaping (APIError?) -> Void)
-    func fetchPollingStations(then callback: @escaping ([PollingStationResponse]?, APIError?) -> Void)
+    func fetchCounties(then callback: @escaping ([CountyResponse]?, APIError?) -> Void)
     func fetchForms(diaspora: Bool, then callback: @escaping ([FormResponse]?, APIError?) -> Void)
     func fetchForm(withId formId: Int,
                    then callback: @escaping ([FormSectionResponse]?, APIError?) -> Void)
@@ -118,7 +118,7 @@ class APIManager: NSObject, APIManagerType {
             }
     }
     
-    func fetchPollingStations(then callback: @escaping ([PollingStationResponse]?, APIError?) -> Void) {
+    func fetchCounties(then callback: @escaping ([CountyResponse]?, APIError?) -> Void) {
         let url = ApiURL.pollingStationList.url()
         let headers = authorizationHeaders()
         
@@ -129,7 +129,7 @@ class APIManager: NSObject, APIManagerType {
                 if statusCode == 200,
                     let data = response.data {
                     do {
-                        let stations = try JSONDecoder().decode([PollingStationResponse].self, from: data)
+                        let stations = try JSONDecoder().decode([CountyResponse].self, from: data)
                         callback(stations, nil)
                     } catch {
                         callback(nil, .incorrectFormat(reason: error.localizedDescription))

--- a/MonitorizareVot/ApiModels.swift
+++ b/MonitorizareVot/ApiModels.swift
@@ -90,12 +90,13 @@ struct LoginResponse: Codable {
     }
 }
 
-struct PollingStationResponse: Codable {
+struct CountyResponse: Codable {
     var id: Int
     var name: String
     var code: String
-    var limit: Int
+    var numberOfPollingStations: Int
     var diaspora: Bool?
+    var order: Int
 }
 
 struct FormListResponse: Codable {

--- a/MonitorizareVot/ApiURL.swift
+++ b/MonitorizareVot/ApiURL.swift
@@ -22,7 +22,7 @@ enum ApiURL {
         var uri = ""
         switch self {
         case .login: uri = "/v1/access/authorize"
-        case .pollingStationList: uri = "/v1/polling-station"
+        case .pollingStationList: uri = "/v1/county"
         case .pollingStation: uri = "/v1/polling-station"
         case .forms: uri = "/v1/form"
         case .form(let id): uri = "/v1/form/\(id)"

--- a/MonitorizareVot/ApplicationData.swift
+++ b/MonitorizareVot/ApplicationData.swift
@@ -21,7 +21,7 @@ class ApplicationData: NSObject {
         // for diaspora we might have different forms, so first check if the user is in diaspora or not
         var isCountyDiaspora = false
         if let countyCode = PreferencesManager.shared.county,
-            let stationCounty = LocalStorage.shared.getPollingStationResponse(withCode: countyCode) {
+            let stationCounty = LocalStorage.shared.getCounty(withCode: countyCode) {
             isCountyDiaspora = stationCounty.diaspora ?? false
         }
         

--- a/MonitorizareVot/LocalStorage.swift
+++ b/MonitorizareVot/LocalStorage.swift
@@ -26,10 +26,10 @@ enum LocalFilename {
 
 protocol LocalStorageType: NSObject {
     
-    var pollingStations: [PollingStationResponse]? { set get }
+    var counties: [CountyResponse]? { set get }
     var forms: [FormResponse]? { set get }
 
-    func getPollingStationResponse(withCode code: String) -> PollingStationResponse?
+    func getCounty(withCode code: String) -> CountyResponse?
     func getFormSummary(withCode code: String) -> FormResponse?
     func loadForm(withId formId: Int) -> [FormSectionResponse]?
     func saveForm(_ form: [FormSectionResponse], withId formId: Int)
@@ -46,7 +46,7 @@ class LocalStorage: NSObject, LocalStorageType {
     
     // MARK: - Public
     
-    var pollingStations: [PollingStationResponse]? {
+    var counties: [CountyResponse]? {
         set {
             if let newValue = newValue {
                 save(codable: newValue, withFilename: .pollingStations)
@@ -54,7 +54,7 @@ class LocalStorage: NSObject, LocalStorageType {
                 delete(fileWithName: .pollingStations)
             }
         } get {
-            return load(type: [PollingStationResponse].self, withFilename: .pollingStations)
+            return load(type: [CountyResponse].self, withFilename: .pollingStations)
         }
     }
     
@@ -83,9 +83,9 @@ class LocalStorage: NSObject, LocalStorageType {
         return forms.filter { $0.code == code }.first
     }
     
-    func getPollingStationResponse(withCode code: String) -> PollingStationResponse? {
-        guard let stations = pollingStations else { return nil }
-        return stations.filter { $0.code == code }.first
+    func getCounty(withCode code: String) -> CountyResponse? {
+        guard let counties = counties else { return nil }
+        return counties.filter { $0.code == code }.first
     }
 
     // MARK: - Internal


### PR DESCRIPTION
Implemented county `order` field in sort;
Updated to use new `/v1/county` API endpoint;
Renamed some structs to be more easily readable (`PollingStationResponse` is now `County`, since it returns a list of counties)
Closes #186 