### PR TITLE
Migration crash fix

### DIFF
--- a/MonitorizareVot/CoreDataInitialiser.swift
+++ b/MonitorizareVot/CoreDataInitialiser.swift
@@ -44,7 +44,8 @@ final class CoreData: NSObject {
         let url = applicationDocumentsDirectory.appendingPathComponent(containerName! + ".sqlite")
         var failureReason = "There was an error creating or loading the application's saved data."
         do {
-            let options = [ NSMigratePersistentStoresAutomaticallyOption: true ]
+            let options = [ NSMigratePersistentStoresAutomaticallyOption: true,
+                            NSInferMappingModelAutomaticallyOption: true]
             try coordinator.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: url, options: options)
         } catch {
             var dict = [String: AnyObject]()

--- a/MonitorizareVot/CoreDataInitialiser.swift
+++ b/MonitorizareVot/CoreDataInitialiser.swift
@@ -44,7 +44,8 @@ final class CoreData: NSObject {
         let url = applicationDocumentsDirectory.appendingPathComponent(containerName! + ".sqlite")
         var failureReason = "There was an error creating or loading the application's saved data."
         do {
-            try coordinator.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: url, options: nil)
+            let options = [ NSMigratePersistentStoresAutomaticallyOption: true ]
+            try coordinator.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: url, options: options)
         } catch {
             var dict = [String: AnyObject]()
             dict[NSLocalizedDescriptionKey] = "Failed to initialize the application's saved data" as AnyObject?

--- a/MonitorizareVot/Note+CoreDataProperties.swift
+++ b/MonitorizareVot/Note+CoreDataProperties.swift
@@ -18,7 +18,6 @@ extension Note {
 
     @NSManaged public var body: String?
     @NSManaged public var questionID: Int16
-    @NSManaged public var file: NSData?
     @NSManaged public var synced: Bool
     @NSManaged public var sectionInfo: SectionInfo?
     @NSManaged public var date: Date?

--- a/MonitorizareVot/Note+CoreDataProperties.swift
+++ b/MonitorizareVot/Note+CoreDataProperties.swift
@@ -18,6 +18,7 @@ extension Note {
 
     @NSManaged public var body: String?
     @NSManaged public var questionID: Int16
+    @NSManaged public var file: NSData?
     @NSManaged public var synced: Bool
     @NSManaged public var sectionInfo: SectionInfo?
     @NSManaged public var date: Date?

--- a/MonitorizareVot/s.xcdatamodeld/s.xcdatamodel/contents
+++ b/MonitorizareVot/s.xcdatamodeld/s.xcdatamodel/contents
@@ -8,7 +8,7 @@
         <attribute name="text" optional="YES" attributeType="String"/>
         <relationship name="question" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Question" inverseName="answers" inverseEntity="Question"/>
     </entity>
-    <entity name="Note" representedClassName="Note" versionHashModifier="1" syncable="YES">
+    <entity name="Note" representedClassName="Note" versionHashModifier="2" syncable="YES">
         <attribute name="body" optional="YES" attributeType="String"/>
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="file" optional="YES" attributeType="Binary"/>

--- a/MonitorizareVot/s.xcdatamodeld/s.xcdatamodel/contents
+++ b/MonitorizareVot/s.xcdatamodeld/s.xcdatamodel/contents
@@ -11,7 +11,6 @@
     <entity name="Note" representedClassName="Note" versionHashModifier="2" syncable="YES">
         <attribute name="body" optional="YES" attributeType="String"/>
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="file" optional="YES" attributeType="Binary"/>
         <attribute name="questionID" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="synced" attributeType="Boolean" usesScalarValueType="YES"/>
         <relationship name="attachments" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="NoteAttachment" inverseName="parentNote" inverseEntity="NoteAttachment"/>
@@ -48,7 +47,7 @@
     </entity>
     <elements>
         <element name="Answer" positionX="376" positionY="459" width="128" height="133"/>
-        <element name="Note" positionX="198" positionY="288" width="128" height="148"/>
+        <element name="Note" positionX="198" positionY="288" width="128" height="133"/>
         <element name="NoteAttachment" positionX="180" positionY="405" width="128" height="103"/>
         <element name="Question" positionX="178" positionY="447" width="128" height="193"/>
         <element name="SectionInfo" positionX="-11" positionY="252" width="128" height="178"/>

--- a/MonitorizareVot/s.xcdatamodeld/s.xcdatamodel/contents
+++ b/MonitorizareVot/s.xcdatamodeld/s.xcdatamodel/contents
@@ -11,6 +11,7 @@
     <entity name="Note" representedClassName="Note" versionHashModifier="1" syncable="YES">
         <attribute name="body" optional="YES" attributeType="String"/>
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="file" optional="YES" attributeType="Binary"/>
         <attribute name="questionID" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="synced" attributeType="Boolean" usesScalarValueType="YES"/>
         <relationship name="attachments" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="NoteAttachment" inverseName="parentNote" inverseEntity="NoteAttachment"/>
@@ -47,9 +48,9 @@
     </entity>
     <elements>
         <element name="Answer" positionX="376" positionY="459" width="128" height="133"/>
-        <element name="Note" positionX="198" positionY="288" width="128" height="133"/>
+        <element name="Note" positionX="198" positionY="288" width="128" height="148"/>
+        <element name="NoteAttachment" positionX="180" positionY="405" width="128" height="103"/>
         <element name="Question" positionX="178" positionY="447" width="128" height="193"/>
         <element name="SectionInfo" positionX="-11" positionY="252" width="128" height="178"/>
-        <element name="NoteAttachment" positionX="180" positionY="405" width="128" height="103"/>
     </elements>
 </model>


### PR DESCRIPTION
Fixes a crash when doing a lightweight core data migration from older data (caused by the removal of the single attachment field)